### PR TITLE
feat: add module registration and module.xml for Mauro_CartReminder(#1)

### DIFF
--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="Mauro_CartReminder" setup_version="1.0.0"/>
+</config>

--- a/registration.php
+++ b/registration.php
@@ -1,0 +1,6 @@
+<?php
+\Magento\Framework\Component\ComponentRegistrar::register(
+    \Magento\Framework\Component\ComponentRegistrar::MODULE,
+    'Mauro_CartReminder',
+    __DIR__
+);


### PR DESCRIPTION
This PR initializes the Mauro_CartReminder module by adding the registration.php file and module.xml configuration.  
It ensures Magento can detect and install the module during setup:upgrade.  
No functional code or frontend templates are included at this stage.