### PR TITLE
feat: add CartReminder block, template, and layout for customer account page(#3)

### DIFF
--- a/Block/CartReminder.php
+++ b/Block/CartReminder.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Mauro\CartReminder\Block;
+
+use Magento\Framework\View\Element\Template;
+use Magento\Checkout\Model\Cart;
+use Magento\Catalog\Helper\Image;
+
+class CartReminder extends Template
+{
+    protected Cart $cart;
+    protected Image $imageHelper;
+
+    public function __construct(
+        Template\Context $context,
+        Cart $cart,
+        Image $imageHelper,
+        array $data = []
+    ) {
+        parent::__construct($context, $data);
+        $this->cart = $cart;
+        $this->imageHelper = $imageHelper;
+    }
+
+    public function getFilteredItems(): array
+    {
+        $items = $this->cart->getQuote()->getAllVisibleItems();
+
+        $filtered = [];
+        $count = 0;
+
+        foreach ($items as $item) {
+            $product = $item->getProduct();
+
+            if (in_array(14, $product->getCategoryIds())) {
+                $filtered[] = [
+                    'name' => $product->getName(),
+                    'url' => $product->getProductUrl(),
+                    'image' => $this->imageHelper
+                        ->init($product, 'product_small_image')
+                        ->getUrl()
+                ];
+
+                $count++;
+
+                if ($count >= 3) {
+                    break;
+                }
+            }
+        }
+
+        return $filtered;
+    }
+
+    public function shouldRender(): bool
+    {
+        return count($this->getFilteredItems()) > 0;
+    }
+
+    public function getItemsJson(): string
+    {
+        return json_encode($this->getFilteredItems());
+    }
+}

--- a/view/frontend/layout/customer_account_index.xml
+++ b/view/frontend/layout/customer_account_index.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <head>
+        <css src="Mauro_CartReminder::css/cart-reminder.css"/>
+    </head>
+    <body>
+        <referenceContainer name="content">
+                <block
+                    class="Mauro\CartReminder\Block\CartReminder"
+                    name="cart_reminder_block"
+                    template="Mauro_CartReminder::cart_reminder.phtml"/>
+        </referenceContainer>
+    </body>
+</page>

--- a/view/frontend/templates/cart_reminder.phtml
+++ b/view/frontend/templates/cart_reminder.phtml
@@ -1,0 +1,59 @@
+<?php
+/** @var $block \Mauro\CartReminder\Block\CartReminder */
+
+if (!$block->shouldRender()) {
+    return;
+}
+
+$itemsJson = $block->getItemsJson();
+?>
+
+<div id="cart-reminder-popup"
+     data-bind="scope: 'cartReminder'"
+     class="cart-reminder-overlay">
+
+    <div class="cart-popup-content">
+        <h2>🛍️ Don't Forget These!</h2>
+        <p class="popup-subtitle">
+            Complete the purchase of these products from your cart!
+        </p>
+
+        <div class="product-cards" data-bind="foreach: items">
+            <div class="product-card">
+                <a data-bind="attr: { href: url }">
+                    <div class="product-image-wrapper">
+                        <img data-bind="attr: { src: image, alt: name }"/>
+                    </div>
+                    <p class="product-name" data-bind="text: name"></p>
+                </a>
+            </div>
+        </div>
+
+        <div class="popup-buttons">
+            <button class="btn-complete"
+                    data-bind="click: goToCheckout">
+                Complete Purchase
+            </button>
+
+            <button class="btn-later"
+                    data-bind="click: closePopup">
+                Maybe Later
+            </button>
+        </div>
+    </div>
+</div>
+
+<script type="text/x-magento-init">
+{
+    "#cart-reminder-popup": {
+        "Magento_Ui/js/core/app": {
+            "components": {
+                "cartReminder": {
+                    "component": "Mauro_CartReminder/js/cart-reminder",
+                    "items": <?= $itemsJson ?>
+                }
+            }
+        }
+    }
+}
+</script>


### PR DESCRIPTION
This PR adds the CartReminder block, the frontend template, and the layout XML configuration.  
The block filters cart items and provides JSON data for the frontend component.  
The template renders the popup only when items are available, and the layout injects it into the customer account page.  
CSS and JS functionality will be implemented in subsequent issues.